### PR TITLE
Removed full path for mocha and duplicated author entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     "email": "lima.igorrribeiro@gmail.com",
     "website": "http://github.com/igorlima"
   },
-  "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test/*_spec.js"
-  },
+  "license": "ISC",
   "repository": {
     "type": "git",
     "url": "https://github.com/igorlima/generator-js-type"
@@ -18,13 +16,14 @@
   "keywords": [
     "yeoman-generator"
   ],
-  "author": "lima.igorribeiro@gmail.com",
-  "license": "ISC",
   "dependencies": {
     "lodash": "^3.10.1",
     "yeoman-generator": "^0.20.3"
   },
   "devDependencies": {
     "mocha": "~2.3.3"
-  }
+  },
+  "scripts": {
+    "test": "mocha test/*_spec.js"
+  },
 }

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
   },
   "scripts": {
     "test": "mocha test/*_spec.js"
-  },
+  }
 }


### PR DESCRIPTION
Three main things in this PR:
- **mocha** doesn't need full path for working locally;
- Removed duplicate author entry;
- Re-organized package.json order;
